### PR TITLE
AddTableNameOverrideOptionForSeperateEnvironments

### DIFF
--- a/src/SQLBackupHistoryETL/Functions/Get-AllSourceServersToETL.ps1
+++ b/src/SQLBackupHistoryETL/Functions/Get-AllSourceServersToETL.ps1
@@ -14,17 +14,35 @@ Function Get-AllSourceServersToETL {
         $TargetCredentialObject,
 
         [Parameter(Mandatory = $false)]
-        $TargetAzureDBCertificateAuth
+        $TargetAzureDBCertificateAuth,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        $ServerListTable
 
     )
-  
-    $query = @"
+    
+    if ($ServerListTable) {
+        $query = @"
+            
+    select  sbhss.ServerName
+            ,sbhss.LastETLDatetime
+    from    $($ServerListTable) as sbhss;
+        
+"@
+
+    }
+
+    else {
+        $query = @"
             
     select  sbhss.ServerName
             ,sbhss.LastETLDatetime
     from    Utility.SQLBackupHistorySourceServers as sbhss;
         
 "@
+    }
+    
 
     try {
 
@@ -56,7 +74,7 @@ Function Get-AllSourceServersToETL {
         Write-Error "Failed to retrieve servers to ETL from Server: $ServerInstance"
         Write-Error "Error Message: $_.Exception.Message"
 
-        if($conn){
+        if ($conn) {
             $conn.Close()
         }
 

--- a/src/SQLBackupHistoryETL/Functions/Invoke-SQLBackupHistoryETL.ps1
+++ b/src/SQLBackupHistoryETL/Functions/Invoke-SQLBackupHistoryETL.ps1
@@ -21,7 +21,11 @@ Function Invoke-SQLBackupHistoryETL {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [pscredential]
-        $SourceCredentialObject
+        $SourceCredentialObject,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        $ServerListTable
 
     )
   
@@ -29,7 +33,8 @@ Function Invoke-SQLBackupHistoryETL {
     $AllSourceServers = Get-AllSourceServersToETL -TargetServerInstance $TargetServerInstance `
         -TargetDatabase $TargetDatabase `
         -TargetCredentialObject $TargetCredentialObject `
-        -TargetAzureDBCertificateAuth $TargetAzureDBCertificateAuth
+        -TargetAzureDBCertificateAuth $TargetAzureDBCertificateAuth `
+        -ServerListTable $ServerListTable
 
     foreach ($SourceServer in $AllSourceServers) {
 


### PR DESCRIPTION
When having multiple environments sharing the same target, we need a way to split out the list of source servers by environment